### PR TITLE
Update MTX catalogue from v16.3 to v17.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ PORT=5001
 
 # Database Configuration
 DATABASE_PATH=./data/mtx.db
-DATABASE_VERSION=MTX v16.3
+DATABASE_VERSION=MTX v17.0
 
 # Frontend Configuration
 VITE_PORT=5178

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -44,7 +44,7 @@ graph TB
     end
     
     subgraph "Data Layer"
-        DB[(SQLite Database<br/>MTX v16.3<br/>31,652 terms)]
+        DB[(SQLite Database<br/>MTX v17.0<br/>31,680 terms)]
         Cache[Cache Manager<br/>TTL: 3600s]
     end
     
@@ -269,7 +269,7 @@ erDiagram
 The SQLite database (converted from MTX Excel) contains:
 
 ```sql
--- Main terms table (31,652 records)
+-- Main terms table (31,680 records)
 CREATE TABLE terms (
     term_code TEXT PRIMARY KEY,      -- e.g., 'A0B9Z'
     extended_name TEXT,              -- e.g., 'Bovine meat'
@@ -282,7 +282,7 @@ CREATE TABLE terms (
     -- ... additional fields
 );
 
--- Term hierarchy relationships (88,642 records)
+-- Term hierarchy relationships (88,817 records)
 CREATE TABLE term_hierarchies (
     term_code TEXT,
     hierarchy_code TEXT,             -- expo, report, master, etc.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example: `A01DJ#F28.A07GH$F01.A05YG` = "Apples, poached, from apple plant"
 
 ## Features
 
-- ✅ **Full code validation** against MTX v16.3 catalogue
+- ✅ **Full code validation** against MTX v17.0 catalogue
 - 🔍 **Term search** with fuzzy matching
 - 📊 **Hierarchy navigation** for exploring food classifications
 - 🏷️ **Facet validation** with valid descriptor lookup
@@ -26,7 +26,7 @@ Example: `A01DJ#F28.A07GH$F01.A05YG` = "Apples, poached, from apple plant"
 - 💻 **Web interface** for interactive validation
 - 📄 **CSV/Excel export** for validation results
 - ⚖️ **Soft rule awareness** that separates critical issues from informational warnings
-- 🗄️ **SQLite database** with 31,652 official terms
+- 🗄️ **SQLite database** with 31,680 official terms
 - 📋 **All 31 business rules** (BR01-BR31) from the original ICT
 
 ## Quick Start
@@ -200,10 +200,10 @@ The validator implements all 31 business rules from the ICT, plus context-specif
 
 The validator uses an SQLite database (`data/mtx.db`) containing:
 
-- **31,652 terms** - All FoodEx2 food items (MTX v16.3)
+- **31,680 terms** - All FoodEx2 food items (MTX v17.0)
 - **39 hierarchies** - Classification structures
 - **51 attributes** - Facets for describing food characteristics
-- **88,642 relationships** - Term-hierarchy mappings
+- **88,817 relationships** - Term-hierarchy mappings
 
 ### Key Tables
 - `terms` - Main term definitions with version tracking
@@ -223,7 +223,7 @@ curl http://localhost:5001/api/database/info
 ```
 
 Response includes:
-- **Catalogue version** (e.g., MTX v16.3)
+- **Catalogue version** (e.g., MTX v17.0)
 - **Total terms** and hierarchies
 - **Version distribution** across all terms
 - **Recent updates** from release notes
@@ -258,7 +258,7 @@ The database is based on the official MTX catalogue from EFSA. To update:
    curl http://localhost:5001/api/database/info | jq '.catalogue'
    ```
 
-**Note**: The current database (v16.3) contains terms spanning versions 3.0 through 16.3, with most terms (66%) from version 8.9. Version 16.3 added 372 new terms.
+**Note**: The current database (v17.0) contains terms spanning versions 3.0 through 17.0, with most terms (66%) from version 8.9. Version 17.0 added 47 new terms.
 
 ## Project Structure
 
@@ -278,7 +278,7 @@ foodex2-validator/
 ├── public/               # Web interface static files
 ├── data/
 │   ├── mtx.db           # SQLite database
-│   ├── MTX_16.2.xlsx    # Source catalogue
+│   ├── MTX_17.0.xlsx    # Source catalogue
 │   ├── BR_Data.csv      # Forbidden processes
 │   ├── warningMessages.txt # Rule definitions
 │   └── warningColors.txt   # UI colors
@@ -362,9 +362,9 @@ To add more validation rules:
 
 ## MTX Catalogue Information
 
-- **Version**: 16.3
+- **Version**: 17.0
 - **Status**: PUBLISHED MINOR
-- **Terms**: 31,652
+- **Terms**: 31,680
 - **Last Update**: 2025-10-02 (see release notes in database)
 
 ## Contributing

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -104,7 +104,7 @@ function initApp() {
     <div class="container">
       <header>
         <h1>FoodEx2 Code Validator</h1>
-        <p class="subtitle">Validate FoodEx2 codes against MTX catalogue v16.3</p>
+        <p class="subtitle">Validate FoodEx2 codes against MTX catalogue v17.0</p>
       </header>
 
       <main>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -129,7 +129,7 @@ PORT=5001
 
 # Database
 DATABASE_PATH=/var/www/foodex2-validator/data/mtx.db
-DATABASE_VERSION=MTX v16.3
+DATABASE_VERSION=MTX v17.0
 
 # Frontend
 VITE_PORT=5178

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -34,7 +34,7 @@ The FoodEx2 Code Validator follows a traditional client-server architecture with
 │     Validators        │        Database Layer                │
 │  ┌──────────────┐    │    ┌─────────────────────┐          │
 │  │ VBA Rules    │    │    │  SQLite Database    │          │
-│  ├──────────────┤    │    │   MTX v16.3         │          │
+│  ├──────────────┤    │    │   MTX v17.0         │          │
 │  │Business Rules│    │    │  31,652 terms       │          │
 │  ├──────────────┤    │    └─────────────────────┘          │
 │  │ Soft Rules   │    │                                      │

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: FoodEx2 Code Validator API
   description: |
     The FoodEx2 Code Validator API provides comprehensive validation services for EFSA's FoodEx2 
-    food classification and description system. It validates codes against the MTX v16.3 catalogue 
+    food classification and description system. It validates codes against the MTX v17.0 catalogue 
     and implements all 31 business rules from the original ICT (Interpreting and Checking Tool).
     
     ## Features

--- a/scripts/import_mtx_to_sqlite.py
+++ b/scripts/import_mtx_to_sqlite.py
@@ -104,7 +104,9 @@ def import_mtx_to_sqlite(excel_path, db_path):
             valid_to TEXT,
             status TEXT,
             deprecated INTEGER DEFAULT 0,
-            hierarchy_groups TEXT
+            hierarchy_groups TEXT,
+            is_reporting INTEGER DEFAULT 0,
+            is_exposure INTEGER DEFAULT 0
         )
     ''')
     
@@ -431,7 +433,7 @@ if __name__ == "__main__":
     # Default paths
     script_dir = os.path.dirname(os.path.abspath(__file__))
     project_dir = os.path.dirname(script_dir)
-    default_excel = os.path.join(project_dir, "data", "MTX_16.3.xlsx")
+    default_excel = os.path.join(project_dir, "data", "MTX_17.0.xlsx")
     default_db = os.path.join(project_dir, "data", "mtx.db")
 
     # Use command-line arguments if provided

--- a/server/import-excel.js
+++ b/server/import-excel.js
@@ -5,7 +5,7 @@ const path = require('path');
 // This script imports the MTX Excel file into SQLite
 // Note: A Python script has already done this, but this is the Node.js version
 
-const excelPath = path.join(__dirname, '../../MTX_16.2.xlsx');
+const excelPath = path.join(__dirname, '../../MTX_17.0.xlsx');
 const dbPath = path.join(__dirname, '../data/mtx.db');
 
 console.log('Reading Excel file...');


### PR DESCRIPTION
## Summary
- Import new MTX v17.0 catalogue: **31,680 terms** (47 new), **88,817 term-hierarchy relationships**
- Fix hierarchies table schema in Python import script (missing `is_reporting`/`is_exposure` columns)
- Update all version references across codebase and documentation (UI, README, docs, OpenAPI spec, .env.example)

## Test plan
- [ ] Start backend and verify `GET /api/database/info` returns v17.0 catalogue info
- [ ] Validate known FoodEx2 codes via UI and API
- [ ] Run `npm test` to check validation tests still pass
- [ ] Verify search functionality works with new term set
- [ ] Confirm re-import works: `python3 scripts/import_mtx_to_sqlite.py` (uses new default path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)