### PR TITLE
Surface all facet removals transparently in the UI

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -512,7 +512,15 @@ function renderResults() {
         <div class="corrected-code-banner">
           <span class="corrected-label">Corrected code:</span>
           <span class="corrected-value">${escapeHtml(result.cleanedCode)}</span>
-          <span class="corrected-note">(invalid facets removed — see warnings below)</span>
+          <span class="corrected-note">(${(() => {
+            const warnings = result.warnings || []
+            const hasImplicit = warnings.some(w => w.rule === 'VBA-IMPLICIT')
+            const hasInvalid = warnings.some(w => w.rule === 'VBA-CATEGORY' || w.rule === 'VBA-FACET404')
+            if (hasImplicit && hasInvalid) return 'implicit and invalid facets removed'
+            if (hasImplicit) return 'implicit facets removed'
+            if (hasInvalid) return 'invalid facets removed'
+            return 'facets removed'
+          })()} — see warnings below)</span>
         </div>
       ` : ''}
 

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -390,6 +390,12 @@ function displaySearchResults(results) {
               <span>${escapeHtml(term.scopeNote)}</span>
             </div>
           ` : ''}
+          ${term.implicitFacets && term.implicitFacets.length > 0 ? `
+            <div class="info-row">
+              <span class="label">Implicit Facets:</span>
+              <span>${term.implicitFacets.map(f => `<span class="facet-tag">${escapeHtml(f.facetCode)} – ${escapeHtml(f.descriptor)}</span>`).join(' ')}</span>
+            </div>
+          ` : ''}
         </div>
       </div>
     `).join('')}
@@ -502,6 +508,14 @@ function renderResults() {
         <span class="level-badge ${(result.severity || 'none').toLowerCase()}">${result.severity || 'NONE'}</span>
       </div>
       
+      ${result.cleanedCode && result.cleanedCode !== result.code ? `
+        <div class="corrected-code-banner">
+          <span class="corrected-label">Corrected code:</span>
+          <span class="corrected-value">${escapeHtml(result.cleanedCode)}</span>
+          <span class="corrected-note">(invalid facets removed — see warnings below)</span>
+        </div>
+      ` : ''}
+
       ${result.baseTerm ? `
         <div class="term-info">
           <div class="info-row">

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -683,6 +683,47 @@ footer a:hover {
   border: 1px solid rgba(37, 99, 235, 0.3);
 }
 
+.corrected-code-banner {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  background: rgba(234, 179, 8, 0.08);
+  border: 1px solid rgba(234, 179, 8, 0.4);
+  border-radius: 6px;
+  font-size: 0.875rem;
+}
+
+.corrected-label {
+  font-weight: 600;
+  color: #92400e;
+}
+
+.corrected-value {
+  font-family: monospace;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.corrected-note {
+  color: #78716c;
+  font-size: 0.8rem;
+}
+
+.facet-tag {
+  display: inline-block;
+  padding: 0.15rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.8rem;
+  font-family: monospace;
+  background: rgba(37, 99, 235, 0.08);
+  color: var(--primary-color);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  margin: 0.1rem 0.2rem 0.1rem 0;
+}
+
 /* Responsive */
 @media (max-width: 768px) {
   .container {

--- a/server/validators/vba-validator.js
+++ b/server/validators/vba-validator.js
@@ -56,13 +56,13 @@ class VBAValidator {
 
         // 6. Validate facet descriptors exist
         const validatedFacets = [];
-        let invalidCategoryRemoved = false;
+        let invalidFacetRemoved = false;
         for (const facet of cleanedFacets) {
             const isValid = await this.validateFacetDescriptor(facet, warnings);
             if (isValid) {
                 validatedFacets.push(facet);
             } else {
-                invalidCategoryRemoved = true;
+                invalidFacetRemoved = true;
             }
         }
 
@@ -74,7 +74,7 @@ class VBAValidator {
 
         // 9. Build final code
         const finalCode = baseTermCode + this.buildFacetString(validatedFacets);
-        const anyRemoved = implicitRemoved || invalidCategoryRemoved;
+        const anyRemoved = implicitRemoved || invalidFacetRemoved;
 
         return {
             valid: warnings.filter(w => w.severity === 'ERROR').length === 0,

--- a/server/validators/vba-validator.js
+++ b/server/validators/vba-validator.js
@@ -56,10 +56,13 @@ class VBAValidator {
 
         // 6. Validate facet descriptors exist
         const validatedFacets = [];
+        let invalidCategoryRemoved = false;
         for (const facet of cleanedFacets) {
             const isValid = await this.validateFacetDescriptor(facet, warnings);
             if (isValid) {
                 validatedFacets.push(facet);
+            } else {
+                invalidCategoryRemoved = true;
             }
         }
 
@@ -71,12 +74,13 @@ class VBAValidator {
 
         // 9. Build final code
         const finalCode = baseTermCode + this.buildFacetString(validatedFacets);
-        
+        const anyRemoved = implicitRemoved || invalidCategoryRemoved;
+
         return {
             valid: warnings.filter(w => w.severity === 'ERROR').length === 0,
             warnings,
             originalCode: baseTermCode + facetString,
-            cleanedCode: implicitRemoved ? finalCode : null,
+            cleanedCode: anyRemoved ? finalCode : null,
             cleanedFacets: validatedFacets,
             baseTerm: baseTermResult.term
         };


### PR DESCRIPTION
## Summary

- The validator was silently dropping facets for two distinct reasons — implicit facets (by design) and wrong-category facets (VBA-CATEGORY/BR31 errors) — but only the implicit removals were tracked when deciding whether to surface a corrected code. Wrong-category removals were invisible.
- `vba-validator.js`: `cleanedCode` is now set whenever **any** facets are removed, not only when implicit ones are stripped.
- `main.js`: A yellow **"Corrected code"** banner is shown in the result card when the validated code differs from what was submitted, with a pointer to the warnings for the full explanation.
- `main.js`: Implicit facets are now shown in the lookup-by-code results.
- `style.css`: Styles for the corrected-code banner and implicit facet tags.

## Why

Users submitting codes with wrong-category facets would see those facets disappear from the interpreted breakdown with no explanation unless they noticed the VBA-CATEGORY warning buried in the messages list. The corrected code banner makes the change immediately obvious.

## Test plan

- [ ] Submit a code with an implicit facet (e.g. `A031G#F01.A057Z`) — banner should appear with the implicit stripped, and VBA-IMPLICIT warning shown
- [ ] Submit a code with a wrong-category facet (e.g. `A031G#F17.A07RY`) — banner should appear, VBA-CATEGORY/BR31 warning explains why
- [ ] Submit a valid code with no removals — no banner shown
- [ ] Lookup a code with implicit facets (e.g. `A031G`) — implicit facets row should appear in results

🤖 Generated with [Claude Code](https://claude.com/claude-code)