### PR TITLE
Upgrade MTX catalogue from v17.0 to v17.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Example: `A01DJ#F28.A07GH$F01.A05YG` = "Apples, poached, from apple plant"
 
 ## Features
 
-- ✅ **Full code validation** against MTX v17.0 catalogue
+- ✅ **Full code validation** against MTX v17.1 catalogue
 - 🔍 **Term search** with fuzzy matching
 - 📊 **Hierarchy navigation** for exploring food classifications
 - 🏷️ **Facet validation** with valid descriptor lookup
@@ -200,7 +200,7 @@ The validator implements all 31 business rules from the ICT, plus context-specif
 
 The validator uses an SQLite database (`data/mtx.db`) containing:
 
-- **31,680 terms** - All FoodEx2 food items (MTX v17.0)
+- **31,690 terms** - All FoodEx2 food items (MTX v17.1)
 - **39 hierarchies** - Classification structures
 - **51 attributes** - Facets for describing food characteristics
 - **88,817 relationships** - Term-hierarchy mappings
@@ -223,7 +223,7 @@ curl http://localhost:5001/api/database/info
 ```
 
 Response includes:
-- **Catalogue version** (e.g., MTX v17.0)
+- **Catalogue version** (e.g., MTX v17.1)
 - **Total terms** and hierarchies
 - **Version distribution** across all terms
 - **Recent updates** from release notes
@@ -258,7 +258,7 @@ The database is based on the official MTX catalogue from EFSA. To update:
    curl http://localhost:5001/api/database/info | jq '.catalogue'
    ```
 
-**Note**: The current database (v17.0) contains terms spanning versions 3.0 through 17.0, with most terms (66%) from version 8.9. Version 17.0 added 47 new terms.
+**Note**: The current database (v17.1) contains terms spanning versions 3.0 through 17.1, with most terms (66%) from version 8.9. Version 17.1 added 410 new/updated terms.
 
 ## Project Structure
 
@@ -278,7 +278,7 @@ foodex2-validator/
 ├── public/               # Web interface static files
 ├── data/
 │   ├── mtx.db           # SQLite database
-│   ├── MTX_17.0.xlsx    # Source catalogue
+│   ├── MTX_17.1.xlsx    # Source catalogue
 │   ├── BR_Data.csv      # Forbidden processes
 │   ├── warningMessages.txt # Rule definitions
 │   └── warningColors.txt   # UI colors
@@ -362,7 +362,7 @@ To add more validation rules:
 
 ## MTX Catalogue Information
 
-- **Version**: 17.0
+- **Version**: 17.1
 - **Status**: PUBLISHED MINOR
 - **Terms**: 31,680
 - **Last Update**: 2025-10-02 (see release notes in database)

--- a/README.md
+++ b/README.md
@@ -364,8 +364,8 @@ To add more validation rules:
 
 - **Version**: 17.1
 - **Status**: PUBLISHED MINOR
-- **Terms**: 31,680
-- **Last Update**: 2025-10-02 (see release notes in database)
+- **Terms**: 31,690
+- **Last Update**: 2026-04-28 (see release notes in database)
 
 ## Contributing
 

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -104,7 +104,7 @@ function initApp() {
     <div class="container">
       <header>
         <h1>FoodEx2 Code Validator</h1>
-        <p class="subtitle">Validate FoodEx2 codes against MTX catalogue v17.0</p>
+        <p class="subtitle">Validate FoodEx2 codes against MTX catalogue v17.1</p>
       </header>
 
       <main>


### PR DESCRIPTION
## Summary

- Regenerated `data/mtx.db` from `data/MTX_17.1.xlsx` (PUBLISHED MINOR, 2026-04-28) via `scripts/import_mtx_to_sqlite.py`
- Bumped UI subtitle in `client/src/main.js` to "v17.1"
- Updated all 7 README references (current version, file path, version note, etc.)
- Backup of the previous DB lives at `data/mtx_v17.0_backup.db` (gitignored, kept locally for rollback)

## Verified end-to-end against the running backend

- `GET /api/database/info` → `version: "17.1"`, `status: "PUBLISHED MINOR"`, `totalTerms: 31690`
- `POST /api/validate {"code":"A01XJ"}` → `valid: true` with proper BR22 message and `baseTerm` populated

## Numbers

| | 17.0 | 17.1 |
|---|---|---|
| Total terms | 31,680 | 31,690 |
| Terms tagged this version | 47 | 410 |
| Published | 2026-01-30 (MAJOR) | 2026-04-28 (MINOR) |

## Test plan

- [x] DB import script ran cleanly (31,690 terms, 39 hierarchies, 51 attributes, 88,848 term-hierarchy relationships, 883 release notes)
- [x] Backend reads new catalogue (`/api/database/info` returns 17.1)
- [x] Validation works on a known term (`A01XJ` Pig liver)
- [ ] After merge: visual sanity check of the UI subtitle + spot-check a 17.1-new term in the validator

## Notes

- `data/MTX_17.1.xlsx` is gitignored by the existing `data/MTX_*.xlsx` rule (same as 17.0) — pull it from EFSA when needed locally.
- Out-of-tree uncommitted server/validator work was preserved on `wip/pre-17.1-upgrade` (local branch) before this change. Not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)