### PR TITLE
docs: BR→ICT-method mapping + Known Divergences (BR26 audit)

### DIFF
--- a/BUSINESS-RULES.md
+++ b/BUSINESS-RULES.md
@@ -28,6 +28,54 @@ For validation purposes we group severities into four categories:
 
 > **Note**: BR02, BR09, and BR18 are placeholders that are currently not implemented and therefore have no severity classification.
 
+## BR → ICT Method Mapping
+
+The validator implements each rule against the EFSA ICT's compiled Java implementation in `data/app.jar` (class `business_rules.TermRules`). The table below maps each BR number to the ICT method that owns the check, plus a one-line summary of what that method does.
+
+| BR | ICT method | Behaviour |
+| --- | --- | --- |
+| BR01 | `sourceCommodityRawCheck` | Raw commodity F27 source-commodity specificity check |
+| BR02 | — | Empty placeholder |
+| BR03 | `sourceInCompositeCheck` | Composite base terms cannot use F01 source facets |
+| BR04 | `sourceCommodityInCompositeCheck` | Composite base terms cannot use F27 source-commodity facets |
+| BR05 | `sourceCommodityDerivativeCheck` | Derivative F27 source-commodity facets must refine an implicit source commodity |
+| BR06 | `sourceCommodityDerivativeCheck` | F01 source is allowed on derivatives only when one F27 source commodity is present |
+| BR07 | `sourceCommodityDerivativeCheck` | F01 source is blocked when derivative has multiple F27 source commodities |
+| BR08 | `isNotReportable` | Base terms not reportable in the reporting hierarchy are forbidden |
+| BR09 | — | Empty placeholder |
+| BR10 | `nonSpecificTermCheck` | Non-specific base terms are discouraged |
+| BR11 | `genericProcessedFacetCheck` | Generic Processed terms under F28 process are discouraged |
+| BR12 | `minorIngredientCheck` | F04 ingredient facets are limited to minor ingredients for derivative/raw commodity terms |
+| BR13 | `physicalStateRawCheck` (gated by `isForbiddenPhysicalState`) | Selected F03 physical states are forbidden on raw primary commodity terms — see BR13 details below for the 7-code list |
+| BR14 | content-provider / ICT-DCF-specific | Declared as ICT/DCF-only in warning message data |
+| BR15 | DCF-specific | Declared as DCF-only in warning message data |
+| BR16 | `checkIfExplicitLessDetailed` | Derivative explicit process ordCode cannot be less detailed than implicit process ordCode |
+| BR17 | `isFacet` | Facet terms cannot be selected as base terms |
+| BR18 | — | Empty placeholder |
+| BR19 | `checkFpForRawCommodity` | Raw commodity terms cannot take configured forbidden process facets from `BR_Data.csv` |
+| BR20 | `isDeprecated` | Deprecated terms are forbidden |
+| BR21 | `isDismissed` | Dismissed terms are forbidden |
+| BR22 | `performWarningChecks` | Success/info message when no high warning is present |
+| BR23 | `hierarchyAsBasetermCheck` | Hierarchy terms as base terms are discouraged |
+| BR24 | `hierarchyAsBasetermCheck` | Hierarchy base terms outside exposure/reporting hierarchy are high warnings |
+| BR25 | single-cardinality facet check | More than one explicit facet in a single-cardinality facet category is forbidden |
+| BR26 | `mutuallyExclusiveCheck` | More than one process with the same ordCode is forbidden on derivative base terms — **the call to this method is commented out in the observed ICT source** (see Known Divergences below) |
+| BR27 | `decimalOrderCheck` | Decimal ordCode process combinations with the same integer part are blocked |
+| BR28 | `reconstitutionCheck` | Reconstitution/dilution process is blocked on concentrate, powder, or dehydrated terms |
+| BR29 | `performWarningChecks` parser | Invalid code structure, unknown base term, or unknown facet term |
+| BR30 | ICT-only facet category validation | Facet category code does not exist |
+| BR31 | ICT-only facet category validation | Facet term does not belong to the supplied facet category hierarchy |
+
+This mapping was extracted from `business_rules/TermRules.class` bytecode and `data/warningMessages.txt`, then cross-checked against an independent extraction. To re-derive it for a future ICT release: `unzip -p data/app.jar business_rules/TermRules.class | strings -n 4 | grep -E '<methodName>'` against each BR number.
+
+## Known Divergences from ICT
+
+This validator aims to be faithful to ICT, but a few rules deserve specific notes:
+
+- **BR13 — list embedded in Java, not in `warningMessages.txt`.** ICT's `isForbiddenPhysicalState` references a 7-code allowlist (Powder, coarse paste/minced, Paste, Puree-type, Fine powder, Coarse powder, Fine paste). The one-line spec in `warningMessages.txt:13` ("if a physical state facet is added to a food rpc term") oversimplifies; our implementation uses the exact 7 codes from the Java source. See BR13 detailed section below.
+- **BR19 — data file frozen.** EFSA's `BR_Data.csv` was last updated on 2020-05-20. It covers 30 root groups; many MTX root groups added since then have no forbidden-process rows, so BR19 cannot fire for them even when domain semantics suggest it should (e.g. Turmeric+Drying). The validator faithfully reproduces ICT behaviour. Local extensions can be enabled — see the BR19 detailed section.
+- **BR26 — practically never fires.** ICT's `mutuallyExclusiveCheck` call appears to be commented out in the observed `TermRules` source. Our implementation has an additional architectural gap: `getProcessOrdinalCode` walks the **report** hierarchy to find a root group, but BR26 only applies to **derivative** base terms — which don't live in the report hierarchy. Result: every process gets ord-code 0, the same-ord-code grouping is empty, and BR26 doesn't fire. This matches ICT behaviour in practice but the underlying cause differs. Fixing this properly requires walking a hierarchy that derivatives actually inhabit (likely `master`) — out of scope for this PR; tracked separately.
+
 ## Term Types
 
 Understanding term types is crucial for validation:


### PR DESCRIPTION
## Summary

Two-part docs PR that came out of the BR13 / BR_Data.csv investigation:

### 1. BR→ICT-method mapping table

A new table in \`BUSINESS-RULES.md\` mapping each BR number to the ICT Java method that owns the check (in \`business_rules.TermRules\`), with a one-line summary. Extracted from the \`data/app.jar\` bytecode and cross-checked against an independent extraction. Useful as a starting point any time someone needs to audit whether our implementation matches ICT.

### 2. Known Divergences section

Three rules where strict ICT-faithfulness has subtle gaps:

- **BR13**: ICT's actual gate is \`isForbiddenPhysicalState\` with a 7-code allowlist, not "any F03". The one-line spec in \`warningMessages.txt:13\` oversimplifies. Fix tracked in PR #16.
- **BR19**: EFSA's \`BR_Data.csv\` hasn't been touched since 2020-05-20; many MTX root groups added since aren't covered, so BR19 can't fire on them. Extension mechanism tracked separately.
- **BR26**: Audited empirically — call appears commented out in ICT, and our impl additionally walks the report hierarchy for ord-code lookup but BR26 targets derivatives which don't live there. Both outcomes: BR26 doesn't fire. Same effect, different causes. Fix-up tracked separately.

## Test plan

- [x] Mapping table verified against \`data/warningMessages.txt\` BR numbers
- [x] Method names verified to exist in \`TermRules.class\` string table
- [x] BR26 empirically tested: \`A002E#F28.A07LG\$F28.A07LH\` (Amaranth flour + Flaking + Flattening) — both processes have BR_Data.csv ord-code 1.0 on root group A000L, but A002E doesn't descend from A000L in the \*report\* hierarchy. Result: no BR26 warning. Confirms the architectural gap.

## Notes

- Docs-only — no code/data changes
- BR13 and BR19 follow-up work referenced is tracked in PR #16 and the upcoming BR19-extension PR respectively

🤖 Generated with [Claude Code](https://claude.com/claude-code)