### PR TITLE
feat(BR19): additive extension layer for forbidden processes

### DIFF
--- a/BUSINESS-RULES.md
+++ b/BUSINESS-RULES.md
@@ -28,6 +28,42 @@ For validation purposes we group severities into four categories:
 
 > **Note**: BR02, BR09, and BR18 are placeholders that are currently not implemented and therefore have no severity classification.
 
+## BR19 Extension Layer (`BR19+`)
+
+ICT's BR19 check ("forbidden processes on raw commodities") reads from `data/BR_Data.csv`, a CSV maintained in `openefsa/catalogue-browser`. That file was last updated on **2020-05-20** (commit `7bc147fb`), covers 30 root groups, and has not been refreshed as MTX has grown over subsequent releases (we're currently on MTX 17.1). Many root groups added since are not represented, so BR19 cannot fire on them even when the same semantic clearly applies — for example, drying a raw commodity to produce a derivative.
+
+A concrete instance: drying turmeric (`A01AC#F28.A07KG`). Drying turmeric roots produces dried/powdered turmeric, a derivative. EFSA's BR_Data.csv forbids `A07KG` (Drying) on `A07XJ` (Garden vegetables) for exactly this reason, but the file has no row for `A0CGZ` (Turmeric roots and similar). Stock ICT — and our validator running in strict ICT-parity mode — does not flag this code. Stock behaviour is faithful but practically misses a case that domain semantics clearly cover.
+
+To bridge this without modifying EFSA's data file, this repository ships an additive companion file: **`data/BR_Data.extension.csv`**. It uses the same five columns as the official file plus two transparency columns:
+
+| Column | From EFSA file | Added in extension |
+| --- | :---: | :---: |
+| `ROOT_GROUP_CODE` | ✓ | ✓ |
+| `ROOT_GROUP_LABEL` | ✓ | ✓ |
+| `FORBIDDEN_PROCS` | ✓ | ✓ |
+| `FORBIDDEN_PROCS_LABELS` | ✓ | ✓ |
+| `ORDINAL_CODE` | ✓ | ✓ |
+| `RATIONALE` | | ✓ — why this row was added, with a parallel from EFSA's existing rows |
+| `ADDED` | | ✓ — date the row was added |
+
+### Behaviour
+
+- The official `data/BR_Data.csv` is loaded first, byte-for-byte as EFSA ships it, and is never modified.
+- `data/BR_Data.extension.csv` is loaded after, and its rows are appended to the in-memory rule list.
+- Extension rows are tagged `source: 'extension'`; official rows are tagged `source: 'efsa'`.
+- When a BR19 firing comes from an extension row, the rule label in the warning is **`BR19+`** (not plain `BR19`) and the warning carries the rationale and date as fields. This makes it transparent in API responses, exports, and UI which firings came from the official ICT data and which from the local extension.
+- An EFSA row always wins over an extension row covering the same `(root group, process)` pair — the official data is the source of truth where it exists.
+
+### Strict ICT parity
+
+Set the environment variable `STRICT_ICT_PARITY=1` to disable the extension entirely. The validator then behaves exactly as if only the EFSA file existed — useful when you need to confirm a code's behaviour against stock ICT, or when comparing notes with someone who runs the official tool.
+
+### Adding a row
+
+Each row in `BR_Data.extension.csv` requires a non-empty `RATIONALE` and `ADDED` date. The expectation is that every addition has a clear parallel to an existing EFSA row — "EFSA forbids X on root group Y; the new row Z follows the same pattern because…" — so reviewers can sanity-check the semantic. Speculative additions without a parallel are not the goal; this file is meant to cover gaps that look like data freshness, not policy disagreements.
+
+If you've added rows you believe should be in the upstream EFSA file, please consider also opening a PR or issue against [openefsa/catalogue-browser](https://github.com/openefsa/catalogue-browser) so other ICT users benefit too. Local extension is a workaround; upstream is the long-term home.
+
 ## Term Types
 
 Understanding term types is crucial for validation:

--- a/data/BR_Data.extension.csv
+++ b/data/BR_Data.extension.csv
@@ -1,0 +1,2 @@
+ROOT_GROUP_CODE;ROOT_GROUP_LABEL;FORBIDDEN_PROCS;FORBIDDEN_PROCS_LABELS;ORDINAL_CODE;RATIONALE;ADDED
+A0CGZ;Turmeric roots and similar-;A07KG;Drying (dehydration);6;Same pattern as EFSA row A07XJ + A07KG (Garden vegetables forbid Drying) — turmeric is a raw rhizome and drying produces a derivative (dried/powdered turmeric). EFSA BR_Data.csv frozen at 2020-05-20 does not yet cover A0CGZ.;2026-06-07

--- a/server/validators/business-rules-validator.js
+++ b/server/validators/business-rules-validator.js
@@ -352,7 +352,8 @@ class BusinessRulesValidator {
         for (const facet of explicitFacets.filter(f => f.startsWith('F28.'))) {
             const processCode = facet.split('.')[1];
 
-            if (forbiddenForTerm.includes(processCode)) {
+            const matchedRule = forbiddenForTerm.find(r => r.forbiddenProcessCode === processCode);
+            if (matchedRule) {
                 // Get process term details for better error message
                 const processTermRow = await this.db.get(
                     'SELECT extended_name FROM terms WHERE term_code = ?',
@@ -361,10 +362,21 @@ class BusinessRulesValidator {
                 const processName = processTermRow ? processTermRow.extended_name : processCode;
                 const baseTermName = baseTerm.extended_name || baseTerm.name || baseTerm.code;
 
-                // Create a more specific warning message
+                const isExtension = matchedRule.source === 'extension';
+                const ruleLabel = isExtension ? 'BR19+' : 'BR19';
+                const sourceTag = isExtension
+                    ? ` [extension: ${matchedRule.rationale ? matchedRule.rationale.split('.')[0] : 'local addition'}]`
+                    : '';
+
                 const specificWarning = this.createWarning('BR19', processCode);
-                specificWarning.message = `BR19> Process ${facet} (${processName}) creates a derivative from raw commodity ${baseTerm.code} (${baseTermName}) and is forbidden. Start from the existing derivative base term instead.`;
+                specificWarning.rule = ruleLabel;
+                specificWarning.message = `${ruleLabel}> Process ${facet} (${processName}) creates a derivative from raw commodity ${baseTerm.code} (${baseTermName}) and is forbidden. Start from the existing derivative base term instead.${sourceTag}`;
                 specificWarning.facet = facet;
+                specificWarning.source = matchedRule.source || 'efsa';
+                if (isExtension) {
+                    specificWarning.extensionRationale = matchedRule.rationale;
+                    specificWarning.extensionAdded = matchedRule.added;
+                }
                 warnings.push(specificWarning);
             }
         }
@@ -537,15 +549,24 @@ class BusinessRulesValidator {
         const ancestors = await this.hierarchyHelper.getAncestors(termCode, 'report');
         ancestors.push(termCode); // Include the term itself
 
-        // Check forbidden processes for each ancestor
+        // Check forbidden processes for each ancestor. Returns the full rule
+        // objects (not just process codes) so BR19 can surface whether the
+        // firing came from EFSA's data file or our extension.
         for (const ancestorCode of ancestors) {
-            const processes = this.forbiddenProcesses
-                .filter(fp => fp.rootGroupCode === ancestorCode)
-                .map(fp => fp.forbiddenProcessCode);
-            forbidden.push(...processes);
+            const rules = this.forbiddenProcesses.filter(fp => fp.rootGroupCode === ancestorCode);
+            forbidden.push(...rules);
         }
 
-        return [...new Set(forbidden)]; // Remove duplicates
+        // De-dup by (root, process), preferring EFSA rows over extension rows
+        // so an extension row never overrides an existing official row.
+        const seen = new Map();
+        for (const r of forbidden) {
+            const key = `${r.rootGroupCode}|${r.forbiddenProcessCode}`;
+            if (!seen.has(key) || (seen.get(key).source === 'extension' && r.source !== 'extension')) {
+                seen.set(key, r);
+            }
+        }
+        return [...seen.values()];
     }
 
     /**

--- a/server/validators/data-loader.js
+++ b/server/validators/data-loader.js
@@ -9,11 +9,36 @@ class DataLoader {
     }
 
     /**
-     * Load forbidden processes from BR_Data.csv
+     * Load forbidden processes from BR_Data.csv.
+     *
+     * Reads EFSA's canonical BR_Data.csv first (faithful to ICT), then
+     * additively concatenates rows from BR_Data.extension.csv if it exists.
+     * Extension rows carry `source: 'extension'` so consumers (and the BR19
+     * warning generator) can surface that a particular firing came from our
+     * extension rather than from EFSA's data file.
+     *
+     * Set the env var STRICT_ICT_PARITY=1 to skip the extension entirely and
+     * behave exactly like the upstream ICT tool.
+     *
+     * EFSA's BR_Data.csv was last updated 2020-05-20 on
+     * openefsa/catalogue-browser. The extension exists to add rows for
+     * root groups added to MTX after that date that are not yet represented
+     * in the official data file. See BUSINESS-RULES.md for the framing and
+     * data/BR_Data.extension.csv for the rationale on each added row.
      */
     async loadForbiddenProcesses() {
-        const filePath = path.join(this.dataPath, 'BR_Data.csv');
-        
+        const official = await this._loadCsvAsRules(path.join(this.dataPath, 'BR_Data.csv'), 'BR_Data.csv', 'efsa');
+
+        if (process.env.STRICT_ICT_PARITY === '1') {
+            return official;
+        }
+
+        const extension = await this._loadCsvAsRules(path.join(this.dataPath, 'BR_Data.extension.csv'), 'BR_Data.extension.csv', 'extension', { silentIfMissing: true });
+
+        return official.concat(extension);
+    }
+
+    async _loadCsvAsRules(filePath, label, source, opts = {}) {
         try {
             const fileContent = await fs.readFile(filePath, 'utf-8');
             const records = csvParse.parse(fileContent, {
@@ -27,10 +52,14 @@ class DataLoader {
                 rootGroupLabel: record.ROOT_GROUP_LABEL,
                 forbiddenProcessCode: record.FORBIDDEN_PROCS,
                 forbiddenProcessLabel: record.FORBIDDEN_PROCS_LABELS,
-                ordinalCode: parseFloat(record.ORDINAL_CODE) || 0
+                ordinalCode: parseFloat(record.ORDINAL_CODE) || 0,
+                source,
+                rationale: record.RATIONALE || null,
+                added: record.ADDED || null,
             }));
         } catch (error) {
-            console.error('Error loading BR_Data.csv:', error);
+            if (opts.silentIfMissing && error.code === 'ENOENT') return [];
+            console.error(`Error loading ${label}:`, error);
             return [];
         }
     }


### PR DESCRIPTION
## Summary

Adds an opt-out-able extension layer for BR19 (\"forbidden processes on raw commodities\"). EFSA's \`BR_Data.csv\` has not been updated since 2020-05-20 and covers 30 root groups; many MTX root groups added since aren't represented, so BR19 cannot fire on them in stock ICT.

This PR keeps EFSA's data file untouched and adds a companion \`data/BR_Data.extension.csv\` that the validator loads on top, with full transparency about which rule fired from which source.

## How it works

- \`data/BR_Data.csv\` is loaded first, byte-for-byte from EFSA.
- \`data/BR_Data.extension.csv\` is loaded after and appended to the in-memory rule list.
- Extension rows carry \`source: 'extension'\` plus a \`RATIONALE\` and \`ADDED\` date.
- BR19 firings from extension rows get the label \`BR19+\` (vs plain \`BR19\` for EFSA rows) and the warning payload includes \`source\`, \`extensionRationale\`, and \`extensionAdded\`.
- An EFSA row always wins over an extension row covering the same (root group, process) pair.

## Strict ICT parity

Set \`STRICT_ICT_PARITY=1\` to disable the extension entirely. Useful for verifying behaviour against the stock ICT tool.

## Seed row

| ROOT_GROUP_CODE | ROOT_GROUP_LABEL | FORBIDDEN_PROCS | LABEL | ORD | RATIONALE | ADDED |
|---|---|---|---|---|---|---|
| A0CGZ | Turmeric roots and similar- | A07KG | Drying (dehydration) | 6 | Same pattern as EFSA row A07XJ + A07KG (Garden vegetables forbid Drying) — turmeric is a raw rhizome and drying produces a derivative (dried/powdered turmeric). EFSA BR_Data.csv frozen at 2020-05-20 does not yet cover A0CGZ. | 2026-06-07 |

## Verification

| Mode | \`A01AC#F28.A07KG\` (Turmeric + Drying) | \`A01DJ#F28.A07KG\` (Apples + Drying) |
|---|---|---|
| Default | \`BR19+ / ERROR\` source=extension | \`BR19 / ERROR\` source=efsa |
| \`STRICT_ICT_PARITY=1\` | \`BR22/NONE\` (matches stock ICT) | \`BR19 / ERROR\` source=efsa |

All four checked end-to-end in isolation.

## Framing in the docs

\`BUSINESS-RULES.md\` gets a new \"BR19 Extension Layer\" section. The framing is purely factual:

- EFSA's file was last updated 2020-05-20 and covers 30 root groups
- MTX has grown several versions since
- Many newer root groups aren't represented
- The extension covers gaps that look like data freshness
- The extension is opt-out via env flag
- Users are encouraged to also contribute additions back to \`openefsa/catalogue-browser\` upstream

No editorialising or attribution of blame — just the facts and an invitation to contribute upstream.

## Test plan

- [x] Default mode: Turmeric+Drying fires BR19+ with source='extension'
- [x] Default mode: Apples+Drying still fires plain BR19 with source='efsa' (unchanged)
- [x] STRICT_ICT_PARITY=1: extension skipped, Turmeric+Drying back to no warning
- [x] STRICT_ICT_PARITY=1: Apples+Drying unaffected
- [x] CSV parser handles the extension file format (5 EFSA cols + 2 extras)
- [ ] After merge: a UI cycle to confirm the \`BR19+\` label and rationale text surface cleanly in the warning display

🤖 Generated with [Claude Code](https://claude.com/claude-code)