### PR TITLE
feat(lookup): show facet group for facet descriptors

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -390,6 +390,12 @@ function displaySearchResults(results) {
               <span>${escapeHtml(term.scopeNote)}</span>
             </div>
           ` : ''}
+          ${term.facetGroups && term.facetGroups.length > 0 ? `
+            <div class="info-row">
+              <span class="label">${term.type === 'f' ? 'Facet Group:' : 'Usable as facet:'}</span>
+              <span>${term.facetGroups.map(g => `<span class="facet-tag">${escapeHtml(g.code)} – ${escapeHtml(g.label)}</span>`).join(' ')}</span>
+            </div>
+          ` : ''}
           ${term.implicitFacets && term.implicitFacets.length > 0 ? `
             <div class="info-row">
               <span class="label">Implicit Facets:</span>

--- a/server/foodex2-service.js
+++ b/server/foodex2-service.js
@@ -131,7 +131,20 @@ class FoodEx2Service {
                 params.push(`%${query}%`, `%${query}%`, `%${query}%`, `%${query}%`, query, limit);
         }
 
-        return await this.db.all(sql, params);
+        const rows = await this.db.all(sql, params);
+
+        // Enrich rows that carry a code with their facet group membership so the
+        // UI can show it consistently with the single-term lookup. The 'facet'
+        // search type already returns its own shape and is left untouched.
+        if (searchType !== 'facet') {
+            for (const row of rows) {
+                if (row.code) {
+                    row.facetGroups = await this.getFacetGroupsForTerm(row.code);
+                }
+            }
+        }
+
+        return rows;
     }
 
     /**
@@ -155,14 +168,52 @@ class FoodEx2Service {
         const implicitFacets = term.implicit_facets ?
             await this.parseImplicitFacets(term.implicit_facets) : [];
 
+        // Determine which facet group(s) this term belongs to (for facet descriptors)
+        const facetGroups = await this.getFacetGroupsForTerm(code);
+
         const normalizedTerm = this.normalizeTermRecord(term);
 
         return {
             ...term,
             ...normalizedTerm,
             hierarchies,
-            implicitFacets
+            implicitFacets,
+            facetGroups
         };
+    }
+
+    /**
+     * Resolve the facet group(s) a term belongs to.
+     *
+     * A facet descriptor belongs to a facet group via its membership in that
+     * group's facet hierarchy (term_hierarchies). Each facet hierarchy maps 1:1
+     * to an Fxx attribute via attributes.catalogue_code = 'MTX.<hierarchy_code>'.
+     * A descriptor can belong to more than one facet group.
+     *
+     * @param {string} code - term code
+     * @returns {Promise<Array<{code:string,name:string,label:string,hierarchyCode:string,cardinality:string}>>}
+     */
+    async getFacetGroupsForTerm(code) {
+        const rows = await this.db.all(`
+            SELECT a.code            AS code,
+                   a.label           AS label,
+                   a.name            AS name,
+                   a.single_or_repeatable AS cardinality,
+                   th.hierarchy_code AS hierarchyCode
+            FROM term_hierarchies th
+            JOIN attributes a
+              ON a.catalogue_code = 'MTX.' || th.hierarchy_code
+            WHERE th.term_code = ?
+            ORDER BY a.attribute_order
+        `, [code]);
+
+        return rows.map(r => ({
+            code: r.code,
+            name: r.name,
+            label: r.label || r.name,
+            hierarchyCode: r.hierarchyCode,
+            cardinality: r.cardinality
+        }));
     }
 
     /**


### PR DESCRIPTION
Closes #20

## What

Term lookup showed **Name / Type / Scope Note** but never **which facet group** a facet descriptor belongs to — e.g. `A07VY` ("Made from raw or low heat-treated milk") gave no hint it lives in **F25 (Risky-Ingredient)**. The info was always in the DB (`term_hierarchies` → `attributes` via `catalogue_code = 'MTX.<hierarchy_code>'`), just never surfaced.

## Changes

- **Backend** (`server/foodex2-service.js`)
  - New `getFacetGroupsForTerm(code)` — joins `term_hierarchies` to `attributes` to resolve the Fxx group(s) a term belongs to.
  - `getTermDetails()` now returns `facetGroups`; `searchTerms()` rows are enriched for display consistency.
- **Frontend** (`client/src/main.js`)
  - New result row: **"Facet Group"** for facet descriptors (`type === 'f'`), **"Usable as facet"** for base terms that are also valid descriptors (e.g. an RPC usable under F04/F27).

## Not a validation change

Display-only. Facet-group membership is already enforced at validation time (`VBA-CATEGORY` / **BR31**): a descriptor under the wrong group is a hard ERROR that even names the correct group. Confirmed against the running server.

## Verification

- API: `/term/A07VY` and `/search?q=A07VY` both return `F25 Risky-Ingredient`.
- Browser (Playwright): lookup for `A07VY` renders `Facet Group: F25 – Risky-Ingredient`.
- Edge cases checked: base term `A00AR` (→ "Usable as facet: F04"), multi-group RPC `A000A` Teff grain (→ F27 + F04).

## Note

Text-search enrichment adds one small indexed lookup per result row (≤50). Fine for this local tool; can be batched into a single query if search latency ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)